### PR TITLE
Clarify README.md to mention .xml extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Omnivore OPML Import is a simple script to import OPML files into Omnivore using
 
 ## Installation & Usage
 1. Clone this repository
-2. Copy OPML files into `./import` directory
+2. Copy OPML files into `./import` directory with a `.xml` file extension
 3. Add [Omnivore API key](https://omnivore.app/settings/api) to `.env` file (copy example from `.env.sample`)
 4. Build docker image: `docker build -t omnivore-opml-import .`
 5. Run docker image: `docker run -it --rm omnivore-opml-import`


### PR DESCRIPTION
I'm migrating from Feedly, which defaults to generating an export with an `.opml` extension, which didn't do anything when I placed it in the `import/` directory.

I had to read the source code to figure it out, so save future users some trouble.